### PR TITLE
Melhoria de performance na inclusão de registro

### DIFF
--- a/src/main/java/org/mentabean/jdbc/MySQLBeanSession.java
+++ b/src/main/java/org/mentabean/jdbc/MySQLBeanSession.java
@@ -101,6 +101,7 @@ public class MySQLBeanSession extends AnsiSQLBeanSession {
 		final StringBuilder sb = new StringBuilder("select last_insert_id() from ");
 
 		sb.append(bc.getTableName());
+		sb.append("limit 1");
 
 		try {
 

--- a/src/main/java/org/mentabean/jdbc/MySQLBeanSession.java
+++ b/src/main/java/org/mentabean/jdbc/MySQLBeanSession.java
@@ -101,7 +101,7 @@ public class MySQLBeanSession extends AnsiSQLBeanSession {
 		final StringBuilder sb = new StringBuilder("select last_insert_id() from ");
 
 		sb.append(bc.getTableName());
-		sb.append("limit 1");
+		sb.append(" limit 1");
 
 		try {
 


### PR DESCRIPTION
Em tabelas com muitos registros, a inclusão se torna lenta pois ao retornar o id inserido, é listado todos os registros da tabela, sendo que sempre usa o primeiro registro.